### PR TITLE
Add tests for loading packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ matrix:
 #    - env: TEST_SUITE=testextra GAPPKG=auto
 #    - env: TEST_SUITE=testextra GAPPKG=all
 
+    - env: TEST_SUITE=testpackagesload GAPPKG=single
+    - env: TEST_SUITE=testpackagesload GAPPKG=singleonlyneeded
+    - env: TEST_SUITE=testpackagesload GAPPKG=all
+    - env: TEST_SUITE=testpackagesload GAPPKG=allreversed
+
 services:
   - docker
 

--- a/ci.sh
+++ b/ci.sh
@@ -16,24 +16,120 @@ echo GAPPKG    : $GAPPKG
 
 cd /home/gap/inst/gap-master/
 
-case ${GAPPKG} in
-no)
+case $TEST_SUITE in
+
+testpackagesload)
+
+    case ${GAPPKG} in
+    single|singleonlyneeded)
+
+        cd pkg
+        # skip PolymakeInterface: no polymake installed (TODO: is there a polymake package we can use)
+        rm -rf PolymakeInterface*
+        # skip xgap: no X11 headers, and no means to test it
+        rm -rf xgap*
+        # also skip itc because it requires xgap
+        rm -rf itc*
+        cd ..
+
+        # loading each package in an individual GAP session, with all needed
+        # and suggested packages, or only with needed packages
+
+        if [[ "$GAPPKG" = singleonlyneeded ]]
+        then
+            GAPOPTION=":OnlyNeeded"
+        else
+            GAPOPTION=""
+        fi
+
+        # Load GAP (without packages) and save workspace to speed up test
+        # save names of all packages into a file to be able to iterate over them
+        $GAP -b <<GAPInput
+        SaveWorkspace("testpackagesload.wsp");
+        PrintTo("packagenames", JoinStringsWithSeparator( SortedList(RecNames( GAPInfo.PackagesInfo )),"\n") );
+        QUIT_GAP(0);
+GAPInput
+        for pkg in $(cat packagenames)
+        do
+            $GAP -b -L testpackagesload.wsp <<GAPInput
+            Print("*** Loading $pkg ... \n");
+            if LoadPackage("$pkg",false $GAPOPTION) = true then
+              Print("OK\n");
+            else
+              Print("failed \n");
+              AppendTo("fail.log", "Loading failed : ", "$pkg", "\n");
+            fi;
+GAPInput
+
+        done
+
+        if [[ -f fail.log ]]
+        then
+            echo "Some packages failed to load:"
+            cat fail.log
+            exit 1
+        fi
+        ;;
+
+    all|allreversed)
+
+        cd pkg
+        # skip PolymakeInterface: no polymake installed (TODO: is there a polymake package we can use)
+        rm -rf PolymakeInterface*
+        # skip xgap: no X11 headers, and no means to test it
+        rm -rf xgap*
+        # also skip itc because it requires xgap
+        rm -rf itc*
+        cd ..
+
+        # Test of `LoadAllPackages()` and `LoadAllPackages(:reversed)`
+
+        if [[ "$GAPPKG" = allreversed ]]
+        then
+            GAPOPTION=":reversed"
+        else
+            GAPOPTION=""
+        fi
+
+        $GAP <<GAPInput
+            SetInfoLevel(InfoPackageLoading,4);
+            LoadAllPackages($GAPOPTION);
+            SetInfoLevel(InfoPackageLoading,0);
+            unloads:= Filtered( SortedList(RecNames( GAPInfo.PackagesInfo ) ), s -> LoadPackage(s) = fail );;
+            if Length(unloads)=0 then
+              Print("*** Packages loading tests completed!\n");
+              QUIT_GAP(0);
+            else
+              Print("*** Packages loading tests failed because of:\n", unloads, "\n");
+              QUIT_GAP(1);
+            fi;
+GAPInput
+        ;;
+    esac
+    ;;
+
+*)
+
+    case ${GAPPKG} in
+    no)
     $GAP <<GAPInput
         TestDirectory( [ DirectoriesLibrary( "tst/${TEST_SUITE}" ) ], rec(exitGAP := true) );
         FORCE_QUIT_GAP(1);
 GAPInput
     ;;
-auto)
+    auto)
     $GAPAuto <<GAPInput
         TestDirectory( [ DirectoriesLibrary( "tst/${TEST_SUITE}" ) ], rec(exitGAP := true) );
         FORCE_QUIT_GAP(1);
 GAPInput
     ;;
-all)
+    all)
     $GAP <<GAPInput
         LoadAllPackages();
         TestDirectory( [ DirectoriesLibrary( "tst/${TEST_SUITE}" ) ], rec(exitGAP := true) );
         FORCE_QUIT_GAP(1);
 GAPInput
     ;;    
+    esac;
+
 esac;


### PR DESCRIPTION
This adds four new tests:
```
    - env: TEST_SUITE=testpackagesload GAPPKG=single
    - env: TEST_SUITE=testpackagesload GAPPKG=singleonlyneeded
    - env: TEST_SUITE=testpackagesload GAPPKG=all
    - env: TEST_SUITE=testpackagesload GAPPKG=allreversed
```

The first two check that each package can be loaded with `LoadPackage`, with and without `OnlyNeeded` option.

The last two check that `LoadAllPackages` works, with and without `reversed` option (to exercise loading package one after another in somehow different orders).
